### PR TITLE
Set PWD environment variable

### DIFF
--- a/golang_build.py
+++ b/golang_build.py
@@ -94,6 +94,10 @@ class GolangBuildCommand(sublime_plugin.WindowCommand):
         if (go_bin, env) == (None, None):
             return
 
+        # Set the PWD environment var to the working_dir
+        # so that potential vendor/ folder is scanned used
+        env.update(PWD=working_dir)
+
         if flags is None:
             flags, _ = golangconfig.setting_value(
                 '%s:flags' % task,


### PR DESCRIPTION
When using vendored packages the following error is raised:
`foo.go:14:2: cannot find package "github.com/foo/bar" in any of:...`
This seems to be because the environment variable `PWD` is set to `/Applications/Sublime Text.app/Contents/MacOS` on mac.
If I set PWD to working_dir it works.

Not sure this is the proper way of fixing this, but it is what I did to get it to work.